### PR TITLE
Add link to github

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,9 @@
     <div id="main" class="columns is-variable is-0">
         <div id='map' class='column is-parent is-5'>
         </div>
-        <div id='history' class='column fixed-table-container content is-small'>
+        <div class='column fixed-table-container content is-small'>
+            <div id='history'></div>
+            <p class="footer"><a href="https://github.com/osmlab/osm-deep-history" target="_blank">Source Code on GitHub</a></p>
         </div>
     </div>
 


### PR DESCRIPTION
Add a footer that links to this repo, so it can be easily found from the website.
Also extract the #history-div that is used by JS, so the footer does get in its way.

It looks like this:
![image](https://user-images.githubusercontent.com/111561/89416776-0de80b80-d72e-11ea-83ff-8ec0b5a62a70.png)
